### PR TITLE
Fix missleading menu entry "Open in new Tab"

### DIFF
--- a/orderdetails/locale/orderdetails-translations.de-DE.ts
+++ b/orderdetails/locale/orderdetails-translations.de-DE.ts
@@ -136,8 +136,8 @@ export const orderdetailsTranslations_deDE: I18nTranslation[] = [
         value: 'Öffnen'
     },
     {
-        key: 'pmon.orderdetails.audit-details.tooltip-open-in-new-tab',
-        value: 'In neuem Tab öffnen'
+        key: 'pmon.orderdetails.audit-details.tooltip-open-in-process-modeller',
+        value: 'Im Process Modeller öffnen'
     },
     {
         key: 'pmon.orderdetails.audit-details.label-end-time',

--- a/orderdetails/locale/orderdetails-translations.en-US.ts
+++ b/orderdetails/locale/orderdetails-translations.en-US.ts
@@ -135,8 +135,8 @@ export const orderdetailsTranslations_enUS: I18nTranslation[] = [
         value: 'Open'
     },
     {
-        key: 'pmon.orderdetails.audit-details.tooltip-open-in-new-tab',
-        value: 'Open in new Tab'
+        key: 'pmon.orderdetails.audit-details.tooltip-open-in-process-modeller',
+        value: 'Open in Process Modeller'
     },
     {
         key: 'pmon.orderdetails.audit-details.label-end-time',

--- a/orderdetails/orderdetails.component.ts
+++ b/orderdetails/orderdetails.component.ts
@@ -101,7 +101,7 @@ export class OrderdetailsComponent extends XcTabComponent<void, XoOrderOverviewE
 
         this.menuItems.push(
             <XcMenuItem>{
-                name: 'Open in new Tab', translate: true,
+                name: 'Open in Process Modeller', translate: true,
                 visible: () => true,
                 click: () => {
                     pmodDocumentService.loadWorkflow(this.workflow.toRtc(), this.workflow.toFqn());


### PR DESCRIPTION
Changes in language key and translation for issue #7 to make the menu entry more clear. 